### PR TITLE
Improving logging of method input and output

### DIFF
--- a/src/common/logger.js
+++ b/src/common/logger.js
@@ -37,7 +37,7 @@ logger.logFullError = (err, signature) => {
   }
 
   if (!err.logged) {
-    logger.error(util.inspect(err))
+    logger.error(`Error: ${util.inspect(err)}`)
     err.logged = true
   }
 }

--- a/src/common/logger.js
+++ b/src/common/logger.js
@@ -87,16 +87,16 @@ logger.decorateWithLogging = (service) => {
     const params = method.params || getParams(method)
     service[name] = async function () {
       logger.debug(`ENTER ${name}`)
-      logger.debug('input arguments')
       const args = Array.prototype.slice.call(arguments)
-      logger.debug(util.inspect(_sanitizeObject(_combineObject(params, args))))
+      const combinedArguments = util.inspect(_sanitizeObject(_combineObject(params, args)))
+      logger.debug(`input arguments ${combinedArguments}`)
       try {
         const result = await method.apply(this, arguments)
-        logger.debug(`EXIT ${name}`)
-        logger.debug('output arguments')
         if (result !== null && result !== undefined) {
-          logger.debug(util.inspect(_sanitizeObject(result)))
+          const outputArgs = util.inspect(_sanitizeObject(result))
+          logger.debug(`output arguments ${outputArgs}`)
         }
+        logger.debug(`EXIT ${name}`)
         return result
       } catch (e) {
         logger.logFullError(e, name)


### PR DESCRIPTION
Currently it is logging every line/field of JSON argument in separate line in logs which makes it difficult to locate debug statements which we are trying to locate.

fyi @ThomasKranitsas @rootelement 