### PR TITLE
fix: groups, terms association lost

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,7 @@ workflows:
             branches:
               only:
                 - develop
+                - fix/association-loss
 
       # Production builds are exectuted only on tagged commits to the
       # master branch.


### PR DESCRIPTION
* if v4 challenge api returns 404 immediately after creation of the challenge when replaying the event
* groups and other data are lost; resolve this problem by adding those data without attempting to get
* challenge details from v4 as required info to make those associations is already present