### PR TITLE
#PLAT-2164 Make billing account immutable at the challenge level

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -64,7 +64,8 @@ const dataHandler = (messageSet, topic, partition) => Promise.each(messageSet, a
     const m2mToken = await helper.getM2MToken()
     const v5Challenge = await helper.getRequest(`${config.V5_CHALLENGE_API_URL}/${challengeUuid}`, m2mToken)
     // TODO : Cleanup. Pulling the billingAccountId from the payload, it's not part of the challenge object
-    messageJSON.payload = { billingAccountId: messageJSON.payload.billingAccountId, ...v5Challenge.body }
+    const billingAccountId= _.get(v5Challenge, 'billing.billingAccountId', messageJSON.payload.billingAccountId)
+    messageJSON.payload = { billingAccountId, ...v5Challenge.body }
   } catch (err) {
     logger.debug('Failed to fetch challenge information')
     logger.logFullError(err)


### PR DESCRIPTION
To achieve this, we needed to update the payload in legacy-challenge-processor to fetch the billing account from challenge object 